### PR TITLE
[codex] Add tracked README intent links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ One-command audit and sync for local AI skill folders (Cursor, OpenClaw, etc.).
 
 **Cursor / agent skill pack:** root [`SKILL.md`](SKILL.md) is the **top entry** (default full pipeline with **`--apply`** on dedup/route/sync unless the operator asks for dry-run or sets `SKILLS_AUDITOR_DRY_RUN=1`); layered sub-skills live under [`skills/`](skills/README.md). Optional env: [`config/skills-auditor.pipeline.example.env`](config/skills-auditor.pipeline.example.env).
 
+## Start here
+
+- [Start in 3 minutes](https://r.fulmail.net/r/oss/skills-auditor/readme_top/primary/quickstart/v1)
+- [See examples](https://r.fulmail.net/r/oss/skills-auditor/readme_top/secondary/examples/v1)
+- [Use in CI / automation](https://r.fulmail.net/r/oss/skills-auditor/readme_top/secondary/ci/v1)
+
 ## Why this exists
 
 Skill folders tend to drift over time:
@@ -61,6 +67,8 @@ This installs the **`skills-audit`** console script and enables **`python -m ski
 
 **Without any install:** run **`python3 scripts/skills_audit.py`** from the repo root (it prepends the repo to `sys.path`).
 
+Install not behaving as expected? Start with [Troubleshooting](https://r.fulmail.net/r/oss/skills-auditor/install_block/inline/troubleshoot/v1).
+
 ## Tests
 
 ```bash
@@ -108,6 +116,49 @@ skills-audit sync \
   --map-file config/sources.example.json \
   --apply
 ```
+
+## Examples
+
+Use these command shapes as starting points:
+
+```bash
+# Inspect one install root.
+skills-audit audit --skills-dir "$HOME/.cursor/skills"
+
+# Inspect Cursor and Claude Code roots together.
+skills-audit audit \
+  --skills-dir "$HOME/.cursor/skills" \
+  --skills-dir "$HOME/.claude/skills"
+
+# Preview discovery-driven sync into a project-local Codex root.
+skills-audit sync-discover \
+  --source .agents/skills \
+  --source .cursor/skills \
+  --skills-dir .codex/skills
+```
+
+## CI / Automation
+
+Use dry-run checks in CI first. Fail CI on duplicate names or invalid metadata before allowing any sync job to apply changes.
+
+```bash
+python3 -m unittest discover -s tests -v
+
+skills-audit audit \
+  --skills-dir "$HOME/.codex/skills" \
+  --fail-on-duplicate-names \
+  --metadata-platform codex
+```
+
+Keep `--apply` out of scheduled automation until the audit output is stable and reviewed.
+
+## Troubleshooting
+
+- If `skills-audit` is not found, activate the virtualenv or run `python3 scripts/skills_audit.py` from the repo root.
+- If metadata validation fails, run `skills-audit metadata-repair --platform codex --skills-dir "$HOME/.codex/skills"` first without `--apply`.
+- If a sync would replace a directory, review the dry-run output before adding `--apply`; existing directories are archived before relinking.
+
+[Share a use case](https://r.fulmail.net/r/oss/skills-auditor/footer/secondary/use_case/v1) if your setup needs a dedicated recipe.
 
 ## gstack fork (`plan-ux-review`)
 

--- a/plugins/skill-trace/hooks/hooks.json
+++ b/plugins/skill-trace/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /Users/j.z/code/skills-auditor/scripts/sensor_hook.py --provider codex"
+            "command": "python3 scripts/sensor_hook.py --provider codex"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /Users/j.z/code/skills-auditor/scripts/sensor_hook.py --provider codex"
+            "command": "python3 scripts/sensor_hook.py --provider codex"
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /Users/j.z/code/skills-auditor/scripts/sensor_hook.py --provider codex"
+            "command": "python3 scripts/sensor_hook.py --provider codex"
           }
         ]
       }
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /Users/j.z/code/skills-auditor/scripts/sensor_hook.py --provider codex"
+            "command": "python3 scripts/sensor_hook.py --provider codex"
           }
         ]
       }

--- a/tests/test_sensor_plugin.py
+++ b/tests/test_sensor_plugin.py
@@ -34,8 +34,9 @@ class TestSensorPlugin(unittest.TestCase):
         for event_name in ("SessionStart", "PreToolUse", "PostToolUse", "Stop"):
             self.assertIn(event_name, hooks)
             encoded = json.dumps(hooks[event_name])
-            self.assertIn(str(REPO_ROOT / "scripts" / "sensor_hook.py"), encoded)
+            self.assertIn("python3 scripts/sensor_hook.py", encoded)
             self.assertIn("--provider codex", encoded)
+            self.assertNotIn("/Users/", encoded)
         self.assertNotIn("SessionEnd", hooks)
 
     def test_repo_marketplace_points_at_plugin(self) -> None:


### PR DESCRIPTION
## Summary

- Add tracked README entry links through `r.fulmail.net`
- Add README sections for examples, CI / automation, and troubleshooting
- Add a use-case issue entry point for high-intent feedback
- Replace machine-specific skill-trace hook paths with a repo-relative launcher command so tests pass from any checkout path

Closes #6.

## Measurement boundary

The redirect map records aggregate route intent only: route id, repo, surface, placement, intent, variant, destination, referrer host, UA class, event type, and timestamp. It does not store raw IPs, GitHub usernames, cookies, visitor IDs, or full user agents.

## Validation

- `git diff --check`
- Verified README contains the 5 expected `r.fulmail.net` routes
- `python3 -m unittest discover -s tests -v`
