### PR TITLE
Add skill-run ledger compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ export SKILLS_AUDITOR_DRY_RUN=1
 
 Layered sub-skills live under [`skills/`](skills/README.md). Optional pipeline environment examples live in [`config/skills-auditor.pipeline.example.env`](config/skills-auditor.pipeline.example.env).
 
+## Skill-run ledgers
+
+Use ledgers when an orchestrator, sub-skill, or delegated worker needs a structured record of execution state, side effects, artifacts, traces, and handoffs.
+
+Ledgers use schema `skills-auditor-ledger/v1` and are stored under `.skills-auditor-local/ledgers/` by default. That directory is local and gitignored, matching the existing `.skills-auditor-local/` trigger and sensor logs. Ledgers do not replace route state-machine traces; record those trace files as `trace` resources when you need one run ledger to point at them.
+
+```bash
+skills-audit ledger-create --run-id run-1 --source orchestrator --mode apply
+
+skills-audit ledger-upsert \
+  --run-id run-1 \
+  --id route-trace \
+  --class trace \
+  --locator "$HOME/.skills-auditor/traces/trace.json" \
+  --owner skills-auditor-route \
+  --status preserved \
+  --metadata platform=codex
+
+skills-audit ledger-check --run-id run-1
+skills-audit ledger-summary --run-id run-1
+```
+
+Resource classes are `skill-run`, `subagent-run`, `trace`, `artifact`, and `external-resource`. Statuses are `active`, `completed`, `preserved`, `handoff`, `blocked`, and `failed`. `handoff` rows should include `--handoff-target`; `blocked` rows should include `--blocked-reason`.
+
 ## Tests
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -37,6 +37,14 @@ one hook/transcript JSON payload from stdin or `--input-file` into `.skills-audi
 use `skills-audit audit-sensor-logs` for schema/privacy checks. Sensor logs capture host-exposed
 facts such as tool name and file path; they do not by themselves prove semantic skill usage.
 
+**Execution ledgers:** use `skills-audit ledger-create`, `ledger-upsert`, `ledger-check`, and
+`ledger-summary` to maintain `skills-auditor-ledger/v1` records under
+`.skills-auditor-local/ledgers/`. Ledger rows may track `skill-run`, `subagent-run`, `trace`,
+`artifact`, and `external-resource` resources with statuses `active`, `completed`, `preserved`,
+`handoff`, `blocked`, or `failed`. Record route state-machine JSON as `trace` resources rather
+than replacing the route trace contract; record trigger/sensor log directories as
+`external-resource` or `artifact` rows only when a run needs to hand them off.
+
 Use `skills-audit log-stats` to summarize local log and route trace storage usage.
 
 ## Configuration (optional)
@@ -85,6 +93,36 @@ Use `"${AUDIT_DIRS[@]}"` and `"${DRIFT_FLAG[@]}"` in `skills-audit` invocations.
 | 6 — Close | [`skills/close/SKILL.md`](skills/close/SKILL.md) |
 
 Index: [`skills/README.md`](skills/README.md).
+
+## Execution ledger (optional compatibility layer)
+
+Create a run ledger before a multi-step or delegated audit:
+
+```bash
+skills-audit ledger-create --run-id <run-id> --source <orchestrator> --mode dry-run
+```
+
+Record each sub-skill or worker run as it completes:
+
+```bash
+skills-audit ledger-upsert --run-id <run-id> \
+  --id route-codex --class skill-run --locator "skills-audit route --platform codex" \
+  --owner skills-auditor-route --status completed
+
+skills-audit ledger-upsert --run-id <run-id> \
+  --id route-trace --class trace --locator ~/.skills-auditor/traces/<trace>.json \
+  --owner skills-auditor-route --status preserved
+```
+
+Before handoff or close, run:
+
+```bash
+skills-audit ledger-check --run-id <run-id>
+skills-audit ledger-summary --run-id <run-id>
+```
+
+`active` rows produce warnings. `failed`, missing handoff target, missing
+blocked reason, or schema problems produce errors.
 
 ## Full pipeline recipe (agent-executable)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -28,6 +28,17 @@ skills-audit audit-discovery \
 
 Use this when source roots are shared across tools and the CI job needs to catch discovery collisions.
 
+## Ledger gate
+
+For delegated automation, check the run ledger before handoff:
+
+```bash
+skills-audit ledger-check --run-id "$RUN_ID" --fail-on-warning
+skills-audit ledger-summary --run-id "$RUN_ID"
+```
+
+Use this as a close gate after the run has recorded all `skill-run`, `subagent-run`, `trace`, `artifact`, and `external-resource` rows. `--fail-on-warning` treats active resources as unfinished work.
+
 ## What not to automate first
 
 Do not put `--apply` in scheduled CI until:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -61,3 +61,35 @@ skills-audit metadata-repair \
 ```
 
 Run again with `--apply` only after reading the proposed edits.
+
+## Record a delegated run ledger
+
+```bash
+RUN_ID="skills-auditor-$(date -u +%Y%m%dT%H%M%SZ)"
+
+skills-audit ledger-create \
+  --run-id "$RUN_ID" \
+  --source issue-lifecycle-router \
+  --mode apply
+
+skills-audit ledger-upsert \
+  --run-id "$RUN_ID" \
+  --id route-codex \
+  --class skill-run \
+  --locator "skills-audit route --platform codex --strategy archive --apply" \
+  --owner skills-auditor-route \
+  --status completed
+
+skills-audit ledger-upsert \
+  --run-id "$RUN_ID" \
+  --id route-trace-codex \
+  --class trace \
+  --locator "$HOME/.skills-auditor/traces/<trace-id>.json" \
+  --owner skills-auditor-route \
+  --status preserved
+
+skills-audit ledger-check --run-id "$RUN_ID"
+skills-audit ledger-summary --run-id "$RUN_ID"
+```
+
+Use `--status handoff --handoff-target <target>` when another operator or agent must continue. Use `--status blocked --blocked-reason <reason>` when the run cannot close.

--- a/docs/skill-contract.md
+++ b/docs/skill-contract.md
@@ -50,6 +50,39 @@ The no-install script entry is:
 python3 scripts/skills_audit.py
 ```
 
+## Skill-run ledger contract
+
+Ledgers are an optional compatibility layer for orchestrators that need to prove a delegated run reached a clean close. They do not replace route state-machine traces or local trigger/sensor logs.
+
+- Schema version: `skills-auditor-ledger/v1`.
+- Default path: `.skills-auditor-local/ledgers/<run-id>.json`.
+- Top-level fields: `schema_version`, `run`, `resources`, `checks`.
+- Resource classes: `skill-run`, `subagent-run`, `trace`, `artifact`, `external-resource`.
+- Statuses: `active`, `completed`, `preserved`, `handoff`, `blocked`, `failed`.
+
+Core commands:
+
+```bash
+skills-audit ledger-create --run-id <run-id> --source <orchestrator> --mode dry-run
+
+skills-audit ledger-upsert --run-id <run-id> \
+  --id route-trace --class trace \
+  --locator ~/.skills-auditor/traces/<trace>.json \
+  --owner skills-auditor-route --status preserved
+
+skills-audit ledger-check --run-id <run-id>
+skills-audit ledger-summary --run-id <run-id>
+```
+
+`ledger-check` updates the `checks` block in the ledger. Active rows are warnings. Failed rows, missing handoff targets, missing blocked reasons, invalid resource classes/statuses, and invalid schema metadata are errors.
+
+Existing artifacts should be linked by locator instead of copied into the ledger:
+
+- Route traces stay under `~/.skills-auditor/traces/`.
+- Trigger logs stay under `.skills-auditor-local/logs/`.
+- Sensor logs stay under `.skills-auditor-local/sensors/`.
+- Sync, archive, delete, or report outputs should be recorded as `artifact` rows.
+
 ## Configuration examples
 
 - [`config/sources.example.json`](../config/sources.example.json)

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,3 +12,5 @@ Layered skills under this folder. The **top entry** is the repository root [`../
 | [close](close/SKILL.md) | 6 | Repeat discover audit to confirm end state |
 
 Configuration template: [`../config/skills-auditor.pipeline.example.env`](../config/skills-auditor.pipeline.example.env).
+
+Ledger compatibility: when an orchestrator creates `.skills-auditor-local/ledgers/<run-id>.json`, every sub-skill should record its own `skill-run` row. Sub-skills that create traces, logs, archives, deletes, or sync changes should also record `trace` or `artifact` rows that point to the existing files or external resources.

--- a/skills/close/SKILL.md
+++ b/skills/close/SKILL.md
@@ -23,6 +23,13 @@ skills-audit audit \
   --with-drift
 ```
 
+## Ledger behavior
+
+- Mode: read-only, except optional `git fetch` during drift checks.
+- Suggested row: final `skill-run` for close verification with `status=completed` only when duplicate, metadata, drift, trace, and sync expectations are acceptable for the run.
+- If any previous cycle left `active`, `failed`, or unreasoned `blocked` rows, run `skills-audit ledger-check` and update or hand off those rows before closing.
+- Close does not delete artifacts, route traces, or local logs; record cleanup as a separate `handoff` if retention work is needed.
+
 ## Parent
 
 [`../../SKILL.md`](../../SKILL.md) · Detail: [`../discover/SKILL.md`](../discover/SKILL.md).

--- a/skills/dedup/SKILL.md
+++ b/skills/dedup/SKILL.md
@@ -28,6 +28,13 @@ skills-audit dedup --skills-dir "$HOME/.cursor/skills"
 skills-audit dedup --skills-dir "$HOME/.cursor/skills" --skills-dir "$HOME/.claude/skills" --apply
 ```
 
+## Ledger behavior
+
+- Mode: dry-run is read-only; `--apply` replaces duplicate files with symlinks.
+- Suggested rows: `skill-run` for the dedup cycle and `artifact` rows for any generated report or captured plan output.
+- Applied symlink replacements should be recorded as `artifact` or `external-resource` rows with `status=completed` and locators pointing to the affected skill paths.
+- `skip_multi_version` and other unresolved duplicate cases should be recorded as `blocked` or `handoff` with the next owner.
+
 ## Parent
 
 [`../../SKILL.md`](../../SKILL.md) · Related: [`../route/SKILL.md`](../route/SKILL.md).

--- a/skills/discover/SKILL.md
+++ b/skills/discover/SKILL.md
@@ -48,6 +48,13 @@ skills-audit audit-discovery \
 - Tables: `link_status`, `has_skill_md`, duplicate `name:` **install-root** status (Slash-style recursive scan), optional drift columns.
 - JSON blocks in CLI output for scripting.
 
+## Ledger behavior
+
+- Mode: read-only, except optional `git fetch` during drift checks.
+- Suggested row: `skill-run` for the discover cycle, `completed` when the audit exits cleanly.
+- Drift checks may record each checked repository as `external-resource` with metadata for branch/ahead/behind/dirty counts.
+- No cleanup is expected; unresolved drift or metadata failures should be recorded as `blocked` or `failed` with a reason.
+
 ## Drift behavior
 
 - Symlinked skills with git context: `git fetch`, report synced vs DRIFT (`ahead` / `behind` / `dirty`).

--- a/skills/route/SKILL.md
+++ b/skills/route/SKILL.md
@@ -47,6 +47,14 @@ skills-audit route \
   --trace-dir ./my-traces
 ```
 
+## Ledger behavior
+
+- Mode: dry-run writes route trace JSON but does not change skill files; `--apply` may archive, delete, or keep superseded variants based on `--strategy`.
+- Record the route cycle as a `skill-run` row. While work is open use `status=active`; after trace audit and any apply step, move it to `completed`, `handoff`, `blocked`, or `failed`.
+- Record the emitted state-machine trace as a `trace` row with `status=preserved` and `locator` set to the trace file path.
+- Applied archives/deletes should be recorded as `artifact` or `external-resource` rows with locators for the affected `SKILL.md` or archived path. Do not remove the route trace when cleaning up; the ledger points to it.
+- If routing cannot choose one active variant, mark the relevant row `blocked` with `--blocked-reason` or `handoff` with `--handoff-target`.
+
 ## Parent
 
 [`../../SKILL.md`](../../SKILL.md) · Next: [`../traces/SKILL.md`](../traces/SKILL.md).

--- a/skills/sync/SKILL.md
+++ b/skills/sync/SKILL.md
@@ -38,6 +38,13 @@ skills-audit sync-discover \
 - Raw CLI defaults to dry-run for both `sync` and `sync-discover`; **`/skills-auditor`** top skill defaults to **`--apply`** on sync when `SKILLS_AUDITOR_SYNC_MAP_FILE` is set, unless dry-run or `SKILLS_AUDITOR_DRY_RUN=1`.
 - `sync-discover` converts slash names to top-level install aliases and excludes each target root from its own generated plan to avoid replacing canonical local directories with self-links.
 
+## Ledger behavior
+
+- Mode: dry-run is read-only; `--apply` may create, replace, or relink skill entries in each target root.
+- Suggested rows: `skill-run` for the sync cycle, `external-resource` for the map file or discovery sources, and `artifact` rows for captured sync plans or applied link changes.
+- Applied link changes should include locators for the target skill root entries and metadata such as `action=create_link`, `replace_link`, or `backup_and_link`.
+- Skipped or unsafe actions should become `blocked` rows with the reason, or `handoff` rows when a human/operator must decide.
+
 ## Parent
 
 [`../../SKILL.md`](../../SKILL.md).

--- a/skills/traces/SKILL.md
+++ b/skills/traces/SKILL.md
@@ -25,6 +25,13 @@ skills-audit audit-state-machine --trace-dir ./my-traces
 - **errors**: fix routing or file state before relying on traces.
 - **warnings / info**: e.g. unused state-machine states on small trace sets — often benign.
 
+## Ledger behavior
+
+- Mode: read-only. This cycle audits existing route trace JSON and does not mutate skill files.
+- Suggested rows: `skill-run` for the trace QA cycle and `trace` rows for each route trace directory or file audited.
+- Use `completed` when there are no trace errors. Use `failed` for trace schema or transition errors. Use `blocked` when required trace files are missing and another cycle must regenerate them.
+- Cleanup is limited to operator-approved trace retention; do not delete traces just because the ledger check passed.
+
 ## Parent
 
 [`../../SKILL.md`](../../SKILL.md).

--- a/skills_auditor/cli.py
+++ b/skills_auditor/cli.py
@@ -17,6 +17,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from skills_auditor.ledger import DEFAULT_LEDGER_ROOT, VALID_RESOURCE_CLASSES, VALID_STATUSES
+
 # Sentinel: source applies to all target platforms when syncing / filtering.
 PLATFORM_WILDCARD = "*"
 
@@ -2468,6 +2470,122 @@ def build_parser() -> argparse.ArgumentParser:
         help="Index/summary overhead as a fraction of raw logs (default: 0.1).",
     )
 
+    p_ledger_create = sub.add_parser(
+        "ledger-create",
+        help="Create a local skill-run execution ledger",
+    )
+    p_ledger_create.add_argument(
+        "--ledger-dir",
+        default=str(DEFAULT_LEDGER_ROOT),
+        help=f"Local ledger directory (default: {DEFAULT_LEDGER_ROOT}).",
+    )
+    p_ledger_create.add_argument(
+        "--run-id",
+        default="",
+        help="Stable run id. If omitted, one is generated.",
+    )
+    p_ledger_create.add_argument(
+        "--source",
+        default="manual",
+        help="Producer or orchestrator name (default: manual).",
+    )
+    p_ledger_create.add_argument(
+        "--mode",
+        default="",
+        help="Run mode, e.g. dry-run, apply, review.",
+    )
+
+    p_ledger_upsert = sub.add_parser(
+        "ledger-upsert",
+        help="Create or update one resource row in a local skill-run ledger",
+    )
+    p_ledger_upsert.add_argument(
+        "--ledger-dir",
+        default=str(DEFAULT_LEDGER_ROOT),
+        help=f"Local ledger directory (default: {DEFAULT_LEDGER_ROOT}).",
+    )
+    p_ledger_upsert.add_argument("--run-id", required=True, help="Ledger run id.")
+    p_ledger_upsert.add_argument(
+        "--create-if-missing",
+        action="store_true",
+        help="Create the ledger before upserting when it does not exist.",
+    )
+    p_ledger_upsert.add_argument(
+        "--source",
+        default="manual",
+        help="Producer or orchestrator name for created ledgers (default: manual).",
+    )
+    p_ledger_upsert.add_argument(
+        "--mode",
+        default="",
+        help="Run mode for created ledgers, e.g. dry-run, apply, review.",
+    )
+    p_ledger_upsert.add_argument("--id", required=True, help="Stable resource id.")
+    p_ledger_upsert.add_argument(
+        "--class",
+        dest="resource_class",
+        required=True,
+        choices=sorted(VALID_RESOURCE_CLASSES),
+        help="Resource class.",
+    )
+    p_ledger_upsert.add_argument("--locator", required=True, help="Path, URL, trace id, or external locator.")
+    p_ledger_upsert.add_argument("--owner", required=True, help="Owning skill, sub-skill, or subagent.")
+    p_ledger_upsert.add_argument(
+        "--status",
+        required=True,
+        choices=sorted(VALID_STATUSES),
+        help="Resource status.",
+    )
+    p_ledger_upsert.add_argument("--note", default="", help="Optional note appended to the row.")
+    p_ledger_upsert.add_argument(
+        "--metadata",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Metadata key/value. Repeatable.",
+    )
+    p_ledger_upsert.add_argument(
+        "--handoff-target",
+        default="",
+        help="Required target when status=handoff.",
+    )
+    p_ledger_upsert.add_argument(
+        "--blocked-reason",
+        default="",
+        help="Required reason when status=blocked.",
+    )
+
+    p_ledger_check = sub.add_parser(
+        "ledger-check",
+        help="Validate a local skill-run execution ledger",
+    )
+    p_ledger_check.add_argument(
+        "--ledger-dir",
+        default=str(DEFAULT_LEDGER_ROOT),
+        help=f"Local ledger directory (default: {DEFAULT_LEDGER_ROOT}).",
+    )
+    p_ledger_check.add_argument("--run-id", required=True, help="Ledger run id.")
+    p_ledger_check.add_argument(
+        "--fail-on-warning",
+        action="store_true",
+        help="Return non-zero when warnings exist, including active resources.",
+    )
+
+    p_ledger_summary = sub.add_parser(
+        "ledger-summary",
+        help="Summarize a local skill-run execution ledger",
+    )
+    p_ledger_summary.add_argument(
+        "--ledger-dir",
+        default=str(DEFAULT_LEDGER_ROOT),
+        help=f"Local ledger directory (default: {DEFAULT_LEDGER_ROOT}).",
+    )
+    p_ledger_summary.add_argument(
+        "--run-id",
+        default="",
+        help="Optional ledger run id. If omitted, summarizes every *.json ledger.",
+    )
+
     p_discovery = sub.add_parser(
         "audit-discovery",
         help="Audit discovery-layer collisions and canonical skill selection",
@@ -2968,6 +3086,137 @@ def main() -> int:
                     "events * (parse_seconds + regression_seconds + "
                     "optional_llm_judge_seconds)"
                 ),
+            },
+            indent=2,
+            ensure_ascii=False,
+        ))
+        return 0
+
+    if args.command == "ledger-create":
+        from skills_auditor.ledger import create_ledger, ledger_path
+
+        ledger_root = Path(args.ledger_dir).expanduser()
+        ledger = create_ledger(
+            run_id=args.run_id or None,
+            source=args.source,
+            mode=args.mode,
+            ledger_root=ledger_root,
+        )
+        out = ledger_path(ledger["run"]["id"], ledger_root)
+        print(f"ledger written: {out}")
+        print("\njson:")
+        print(json.dumps(ledger, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.command == "ledger-upsert":
+        from skills_auditor.ledger import (
+            create_ledger,
+            load_ledger,
+            metadata_from_cli,
+            save_ledger,
+            upsert_resource,
+        )
+
+        ledger_root = Path(args.ledger_dir).expanduser()
+        try:
+            metadata = metadata_from_cli(args.metadata)
+            try:
+                ledger = load_ledger(args.run_id, ledger_root)
+            except FileNotFoundError:
+                if not args.create_if_missing:
+                    raise
+                ledger = create_ledger(
+                    run_id=args.run_id,
+                    source=args.source,
+                    mode=args.mode,
+                    ledger_root=ledger_root,
+                )
+            upsert_resource(
+                ledger,
+                resource_id=args.id,
+                resource_class=args.resource_class,
+                locator=args.locator,
+                owner=args.owner,
+                status=args.status,
+                note=args.note,
+                metadata=metadata,
+                handoff_target=args.handoff_target,
+                blocked_reason=args.blocked_reason,
+            )
+        except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        out = save_ledger(ledger, ledger_root)
+        print(f"ledger updated: {out}")
+        print("\njson:")
+        print(json.dumps(ledger, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.command == "ledger-check":
+        from skills_auditor.ledger import audit_ledger, load_ledger, save_ledger, update_checks
+
+        ledger_root = Path(args.ledger_dir).expanduser()
+        try:
+            ledger = load_ledger(args.run_id, ledger_root)
+        except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        findings = audit_ledger(ledger)
+        update_checks(ledger, findings)
+        save_ledger(ledger, ledger_root)
+        errors = [f for f in findings if f.severity == "error"]
+        warnings = [f for f in findings if f.severity == "warning"]
+        infos = [f for f in findings if f.severity == "info"]
+        print(f"ledger: {args.run_id}")
+        print(f"findings: {len(findings)}")
+        print(f"  errors: {len(errors)}, warnings: {len(warnings)}, info: {len(infos)}")
+        for f in findings:
+            prefix = {"error": "ERR", "warning": "WARN", "info": "INFO"}.get(f.severity, "?")
+            parts = [f"[{prefix}] {f.check}: {f.detail}"]
+            if f.resource_id:
+                parts.append(f"resource={f.resource_id}")
+            print("  " + "  ".join(parts))
+        print("\njson:")
+        print(json.dumps(
+            {
+                "checks": ledger.get("checks", {}),
+                "findings": [f.to_dict() for f in findings],
+            },
+            indent=2,
+            ensure_ascii=False,
+        ))
+        if errors or (args.fail_on_warning and warnings):
+            return 1
+        return 0
+
+    if args.command == "ledger-summary":
+        from skills_auditor.ledger import ledger_summary, load_ledger
+
+        ledger_root = Path(args.ledger_dir).expanduser()
+        summaries = []
+        try:
+            if args.run_id:
+                summaries.append(ledger_summary(load_ledger(args.run_id, ledger_root)))
+            elif ledger_root.exists():
+                for path in sorted(ledger_root.glob("*.json")):
+                    summaries.append(ledger_summary(load_ledger(path.stem, ledger_root)))
+        except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        total_resources = sum(s["resource_count"] for s in summaries)
+        print(f"ledgers: {len(summaries)}")
+        print(f"resources: {total_resources}")
+        for summary in summaries:
+            print(
+                f"  {summary['run_id']}: resources={summary['resource_count']} "
+                f"by_status={summary['by_status']} by_class={summary['by_class']}"
+            )
+        print("\njson:")
+        print(json.dumps(
+            {
+                "ledger_count": len(summaries),
+                "resource_count": total_resources,
+                "ledgers": summaries,
             },
             indent=2,
             ensure_ascii=False,

--- a/skills_auditor/ledger.py
+++ b/skills_auditor/ledger.py
@@ -1,0 +1,323 @@
+"""Structured execution ledgers for skill and delegated agent runs."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+SCHEMA_VERSION = "skills-auditor-ledger/v1"
+DEFAULT_LEDGER_ROOT = Path(".skills-auditor-local") / "ledgers"
+
+VALID_RESOURCE_CLASSES = frozenset(
+    {
+        "skill-run",
+        "subagent-run",
+        "trace",
+        "artifact",
+        "external-resource",
+    }
+)
+VALID_STATUSES = frozenset(
+    {
+        "active",
+        "completed",
+        "preserved",
+        "handoff",
+        "blocked",
+        "failed",
+    }
+)
+
+
+def utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def default_run_id() -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    return f"{stamp}-{uuid.uuid4().hex[:8]}"
+
+
+@dataclass
+class LedgerResource:
+    id: str
+    resource_class: str
+    locator: str
+    owner: str
+    status: str
+    notes: List[str] = field(default_factory=list)
+    created_at: str = field(default_factory=utc_timestamp)
+    updated_at: str = field(default_factory=utc_timestamp)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    handoff: Dict[str, str] = field(default_factory=dict)
+    blocked_reason: str = ""
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["class"] = data.pop("resource_class")
+        return data
+
+    @staticmethod
+    def from_dict(data: dict) -> "LedgerResource":
+        return LedgerResource(
+            id=str(data.get("id", "")),
+            resource_class=str(data.get("class", data.get("resource_class", ""))),
+            locator=str(data.get("locator", "")),
+            owner=str(data.get("owner", "")),
+            status=str(data.get("status", "")),
+            notes=list(data.get("notes", []) or []),
+            created_at=str(data.get("created_at", "") or utc_timestamp()),
+            updated_at=str(data.get("updated_at", "") or utc_timestamp()),
+            metadata=dict(data.get("metadata", {}) or {}),
+            handoff=dict(data.get("handoff", {}) or {}),
+            blocked_reason=str(data.get("blocked_reason", "") or ""),
+        )
+
+
+@dataclass
+class LedgerFinding:
+    check: str
+    severity: str
+    detail: str
+    resource_id: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def ledger_path(run_id: str, ledger_root: Optional[Path] = None) -> Path:
+    root = ledger_root or DEFAULT_LEDGER_ROOT
+    return root / f"{run_id}.json"
+
+
+def empty_ledger(
+    run_id: Optional[str] = None,
+    *,
+    source: str = "manual",
+    mode: str = "",
+) -> dict:
+    now = utc_timestamp()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run": {
+            "id": run_id or default_run_id(),
+            "source": source,
+            "mode": mode,
+            "created_at": now,
+            "updated_at": now,
+        },
+        "resources": [],
+        "checks": {
+            "no_active_resources": False,
+            "no_failed_resources": False,
+            "handoffs_have_target": False,
+            "blocked_have_reason": False,
+        },
+    }
+
+
+def save_ledger(ledger: dict, ledger_root: Optional[Path] = None) -> Path:
+    run_id = str(ledger.get("run", {}).get("id", "") or default_run_id())
+    ledger.setdefault("run", {})["id"] = run_id
+    ledger["run"]["updated_at"] = utc_timestamp()
+    out = ledger_path(run_id, ledger_root)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(ledger, indent=2, ensure_ascii=False, sort_keys=True)
+    out.write_text(payload + "\n", encoding="utf-8")
+    return out
+
+
+def create_ledger(
+    *,
+    run_id: Optional[str] = None,
+    source: str = "manual",
+    mode: str = "",
+    ledger_root: Optional[Path] = None,
+) -> dict:
+    ledger = empty_ledger(run_id, source=source, mode=mode)
+    save_ledger(ledger, ledger_root)
+    return ledger
+
+
+def load_ledger(run_id: str, ledger_root: Optional[Path] = None) -> dict:
+    path = ledger_path(run_id, ledger_root)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"ledger must be a JSON object: {path}")
+    data.setdefault("resources", [])
+    data.setdefault("checks", {})
+    return data
+
+
+def _find_resource(ledger: dict, resource_id: str) -> Optional[dict]:
+    for resource in ledger.get("resources", []) or []:
+        if resource.get("id") == resource_id:
+            return resource
+    return None
+
+
+def _parse_metadata(raw: List[str]) -> Dict[str, str]:
+    metadata: Dict[str, str] = {}
+    for item in raw:
+        if "=" not in item:
+            raise ValueError(f"metadata must be key=value, got: {item}")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"metadata key is empty in: {item}")
+        metadata[key] = value
+    return metadata
+
+
+def upsert_resource(
+    ledger: dict,
+    *,
+    resource_id: str,
+    resource_class: str,
+    locator: str,
+    owner: str,
+    status: str,
+    note: str = "",
+    metadata: Optional[Dict[str, Any]] = None,
+    handoff_target: str = "",
+    blocked_reason: str = "",
+) -> dict:
+    if resource_class not in VALID_RESOURCE_CLASSES:
+        raise ValueError(f"invalid resource class: {resource_class}")
+    if status not in VALID_STATUSES:
+        raise ValueError(f"invalid resource status: {status}")
+
+    now = utc_timestamp()
+    resource = _find_resource(ledger, resource_id)
+    if resource is None:
+        resource_obj = LedgerResource(
+            id=resource_id,
+            resource_class=resource_class,
+            locator=locator,
+            owner=owner,
+            status=status,
+            metadata=dict(metadata or {}),
+        )
+        resource = resource_obj.to_dict()
+        ledger.setdefault("resources", []).append(resource)
+    else:
+        resource.update(
+            {
+                "class": resource_class,
+                "locator": locator,
+                "owner": owner,
+                "status": status,
+                "updated_at": now,
+            }
+        )
+        existing_metadata = dict(resource.get("metadata", {}) or {})
+        existing_metadata.update(metadata or {})
+        resource["metadata"] = existing_metadata
+
+    if note:
+        resource.setdefault("notes", []).append(note)
+    if handoff_target:
+        resource["handoff"] = {"target": handoff_target}
+    if blocked_reason:
+        resource["blocked_reason"] = blocked_reason
+    ledger.setdefault("run", {})["updated_at"] = now
+    return ledger
+
+
+def audit_ledger(ledger: dict) -> List[LedgerFinding]:
+    findings: List[LedgerFinding] = []
+    if ledger.get("schema_version") != SCHEMA_VERSION:
+        findings.append(
+            LedgerFinding(
+                "schema_version",
+                "error",
+                f"expected {SCHEMA_VERSION}, got {ledger.get('schema_version')!r}",
+            )
+        )
+    run = ledger.get("run")
+    if not isinstance(run, dict) or not run.get("id"):
+        findings.append(LedgerFinding("run_id", "error", "run.id is required"))
+
+    seen: set[str] = set()
+    for raw in ledger.get("resources", []) or []:
+        resource = LedgerResource.from_dict(raw)
+        if not resource.id:
+            findings.append(LedgerFinding("resource_id", "error", "resource id is required"))
+            continue
+        if resource.id in seen:
+            findings.append(LedgerFinding("duplicate_resource", "error", "resource id is duplicated", resource.id))
+        seen.add(resource.id)
+        if resource.resource_class not in VALID_RESOURCE_CLASSES:
+            findings.append(
+                LedgerFinding("resource_class", "error", f"invalid class: {resource.resource_class}", resource.id)
+            )
+        if resource.status not in VALID_STATUSES:
+            findings.append(LedgerFinding("status", "error", f"invalid status: {resource.status}", resource.id))
+        if not resource.locator:
+            findings.append(LedgerFinding("locator", "error", "locator is required", resource.id))
+        if not resource.owner:
+            findings.append(LedgerFinding("owner", "error", "owner is required", resource.id))
+        if resource.status == "active":
+            findings.append(LedgerFinding("active_resource", "warning", "resource is still active", resource.id))
+        if resource.status == "failed":
+            findings.append(LedgerFinding("failed_resource", "error", "resource failed", resource.id))
+        if resource.status == "handoff" and not resource.handoff.get("target"):
+            findings.append(
+                LedgerFinding(
+                    "handoff_target",
+                    "error",
+                    "handoff resource needs handoff.target",
+                    resource.id,
+                )
+            )
+        if resource.status == "blocked" and not resource.blocked_reason:
+            findings.append(
+                LedgerFinding(
+                    "blocked_reason",
+                    "error",
+                    "blocked resource needs blocked_reason",
+                    resource.id,
+                )
+            )
+    return findings
+
+
+def update_checks(ledger: dict, findings: List[LedgerFinding]) -> dict:
+    resources = [LedgerResource.from_dict(r) for r in ledger.get("resources", []) or []]
+    ledger["checks"] = {
+        "no_active_resources": not any(r.status == "active" for r in resources),
+        "no_failed_resources": not any(r.status == "failed" for r in resources),
+        "handoffs_have_target": not any(
+            r.status == "handoff" and not r.handoff.get("target") for r in resources
+        ),
+        "blocked_have_reason": not any(r.status == "blocked" and not r.blocked_reason for r in resources),
+        "schema_valid": not any(
+            f.severity == "error" for f in findings if f.check in {"schema_version", "run_id"}
+        ),
+    }
+    return ledger
+
+
+def ledger_summary(ledger: dict) -> dict:
+    by_status: Dict[str, int] = {}
+    by_class: Dict[str, int] = {}
+    for raw in ledger.get("resources", []) or []:
+        resource = LedgerResource.from_dict(raw)
+        by_status[resource.status] = by_status.get(resource.status, 0) + 1
+        by_class[resource.resource_class] = by_class.get(resource.resource_class, 0) + 1
+    return {
+        "run_id": ledger.get("run", {}).get("id", ""),
+        "resource_count": len(ledger.get("resources", []) or []),
+        "by_status": by_status,
+        "by_class": by_class,
+        "checks": dict(ledger.get("checks", {}) or {}),
+    }
+
+
+def metadata_from_cli(items: Optional[List[str]]) -> Dict[str, str]:
+    return _parse_metadata(items or [])

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,313 @@
+"""Tests for skill-run execution ledgers."""
+
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from skills_auditor.cli import main
+from skills_auditor.ledger import (
+    SCHEMA_VERSION,
+    audit_ledger,
+    create_ledger,
+    ledger_summary,
+    load_ledger,
+    save_ledger,
+    update_checks,
+    upsert_resource,
+)
+
+
+class TestLedgerCore(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ledger_root = Path(self.tmp.name) / "ledgers"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_create_ledger_writes_schema_and_run_metadata(self) -> None:
+        ledger = create_ledger(
+            run_id="run-1",
+            source="unit-test",
+            mode="dry-run",
+            ledger_root=self.ledger_root,
+        )
+
+        loaded = load_ledger("run-1", self.ledger_root)
+        self.assertEqual(ledger["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(loaded["run"]["id"], "run-1")
+        self.assertEqual(loaded["run"]["source"], "unit-test")
+        self.assertEqual(loaded["run"]["mode"], "dry-run")
+
+    def test_upsert_resource_merges_metadata_and_notes(self) -> None:
+        ledger = create_ledger(run_id="run-1", ledger_root=self.ledger_root)
+        upsert_resource(
+            ledger,
+            resource_id="route-trace",
+            resource_class="trace",
+            locator="traces/route.json",
+            owner="skills-auditor-route",
+            status="active",
+            note="trace planned",
+            metadata={"platform": "codex"},
+        )
+        upsert_resource(
+            ledger,
+            resource_id="route-trace",
+            resource_class="trace",
+            locator="traces/route.json",
+            owner="skills-auditor-route",
+            status="completed",
+            note="trace checked",
+            metadata={"strategy": "archive"},
+        )
+        save_ledger(ledger, self.ledger_root)
+
+        resource = load_ledger("run-1", self.ledger_root)["resources"][0]
+        self.assertEqual(resource["status"], "completed")
+        self.assertEqual(resource["notes"], ["trace planned", "trace checked"])
+        self.assertEqual(resource["metadata"]["platform"], "codex")
+        self.assertEqual(resource["metadata"]["strategy"], "archive")
+
+    def test_check_flags_active_and_failed_resources(self) -> None:
+        ledger = create_ledger(run_id="run-1", ledger_root=self.ledger_root)
+        upsert_resource(
+            ledger,
+            resource_id="worker",
+            resource_class="subagent-run",
+            locator="thread:abc",
+            owner="skills-auditor",
+            status="active",
+        )
+        upsert_resource(
+            ledger,
+            resource_id="artifact",
+            resource_class="artifact",
+            locator="out.json",
+            owner="skills-auditor",
+            status="failed",
+        )
+
+        findings = audit_ledger(ledger)
+        update_checks(ledger, findings)
+
+        self.assertIn("active_resource", [f.check for f in findings])
+        self.assertIn("failed_resource", [f.check for f in findings])
+        self.assertFalse(ledger["checks"]["no_active_resources"])
+        self.assertFalse(ledger["checks"]["no_failed_resources"])
+
+    def test_check_requires_handoff_target_and_blocked_reason(self) -> None:
+        ledger = create_ledger(run_id="run-1", ledger_root=self.ledger_root)
+        upsert_resource(
+            ledger,
+            resource_id="handoff-row",
+            resource_class="skill-run",
+            locator="skills-audit route",
+            owner="skills-auditor-route",
+            status="handoff",
+        )
+        upsert_resource(
+            ledger,
+            resource_id="blocked-row",
+            resource_class="subagent-run",
+            locator="thread:abc",
+            owner="skills-auditor",
+            status="blocked",
+        )
+
+        findings = audit_ledger(ledger)
+        update_checks(ledger, findings)
+
+        self.assertIn("handoff_target", [f.check for f in findings])
+        self.assertIn("blocked_reason", [f.check for f in findings])
+        self.assertFalse(ledger["checks"]["handoffs_have_target"])
+        self.assertFalse(ledger["checks"]["blocked_have_reason"])
+
+    def test_summary_counts_resources_by_status_and_class(self) -> None:
+        ledger = create_ledger(run_id="run-1", ledger_root=self.ledger_root)
+        upsert_resource(
+            ledger,
+            resource_id="skill",
+            resource_class="skill-run",
+            locator="skills/route/SKILL.md",
+            owner="skills-auditor-route",
+            status="completed",
+        )
+        upsert_resource(
+            ledger,
+            resource_id="trace",
+            resource_class="trace",
+            locator="trace.json",
+            owner="skills-auditor-route",
+            status="preserved",
+        )
+
+        summary = ledger_summary(ledger)
+
+        self.assertEqual(summary["resource_count"], 2)
+        self.assertEqual(summary["by_status"]["completed"], 1)
+        self.assertEqual(summary["by_status"]["preserved"], 1)
+        self.assertEqual(summary["by_class"]["skill-run"], 1)
+        self.assertEqual(summary["by_class"]["trace"], 1)
+
+
+class TestLedgerCli(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ledger_root = Path(self.tmp.name) / "ledgers"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _run_cli(self, argv: list[str]) -> tuple[int, str]:
+        stdout = StringIO()
+        with patch("sys.argv", ["skills-audit"] + argv), redirect_stdout(stdout):
+            exit_code = main()
+        return exit_code, stdout.getvalue()
+
+    def test_cli_create_upsert_check_and_summary(self) -> None:
+        exit_code, out = self._run_cli(
+            [
+                "ledger-create",
+                "--ledger-dir",
+                str(self.ledger_root),
+                "--run-id",
+                "run-1",
+                "--source",
+                "unit-test",
+                "--mode",
+                "apply",
+            ]
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertIn("ledger written:", out)
+
+        exit_code, out = self._run_cli(
+            [
+                "ledger-upsert",
+                "--ledger-dir",
+                str(self.ledger_root),
+                "--run-id",
+                "run-1",
+                "--id",
+                "artifact-1",
+                "--class",
+                "artifact",
+                "--locator",
+                "reports/out.json",
+                "--owner",
+                "skills-auditor-sync",
+                "--status",
+                "completed",
+                "--metadata",
+                "mode=apply",
+                "--note",
+                "wrote artifact",
+            ]
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertIn("ledger updated:", out)
+
+        exit_code, out = self._run_cli(
+            [
+                "ledger-check",
+                "--ledger-dir",
+                str(self.ledger_root),
+                "--run-id",
+                "run-1",
+            ]
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertIn("findings: 0", out)
+        self.assertTrue(load_ledger("run-1", self.ledger_root)["checks"]["no_active_resources"])
+
+        exit_code, out = self._run_cli(
+            [
+                "ledger-summary",
+                "--ledger-dir",
+                str(self.ledger_root),
+                "--run-id",
+                "run-1",
+            ]
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertIn("ledgers: 1", out)
+        self.assertIn("artifact-1", json.dumps(load_ledger("run-1", self.ledger_root)))
+
+    def test_cli_upsert_can_create_missing_ledger(self) -> None:
+        exit_code, out = self._run_cli(
+            [
+                "ledger-upsert",
+                "--ledger-dir",
+                str(self.ledger_root),
+                "--run-id",
+                "run-2",
+                "--create-if-missing",
+                "--source",
+                "unit-test",
+                "--id",
+                "worker",
+                "--class",
+                "subagent-run",
+                "--locator",
+                "thread:abc",
+                "--owner",
+                "skills-auditor",
+                "--status",
+                "handoff",
+                "--handoff-target",
+                "operator",
+            ]
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("ledger updated:", out)
+        loaded = load_ledger("run-2", self.ledger_root)
+        self.assertEqual(loaded["run"]["source"], "unit-test")
+        self.assertEqual(loaded["resources"][0]["handoff"]["target"], "operator")
+
+    def test_cli_check_can_fail_on_active_warning(self) -> None:
+        create_ledger(run_id="run-3", ledger_root=self.ledger_root)
+
+        exit_code, _ = self._run_cli(
+            [
+                "ledger-upsert",
+                "--ledger-dir",
+                str(self.ledger_root),
+                "--run-id",
+                "run-3",
+                "--id",
+                "worker",
+                "--class",
+                "subagent-run",
+                "--locator",
+                "thread:abc",
+                "--owner",
+                "skills-auditor",
+                "--status",
+                "active",
+            ]
+        )
+        self.assertEqual(exit_code, 0)
+
+        exit_code, out = self._run_cli(
+            [
+                "ledger-check",
+                "--ledger-dir",
+                str(self.ledger_root),
+                "--run-id",
+                "run-3",
+                "--fail-on-warning",
+            ]
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("active_resource", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add skills-auditor-ledger/v1 JSON ledger support for skill and delegated agent runs
- expose ledger-create/upsert/check/summary CLI commands
- document ledger behavior across the top skill, README, CI/examples, and mutating/trace sub-skills
- add focused unit and CLI tests for create/upsert/check/summary and blocker/handoff validation

## Validation
- python3 -m unittest discover -s tests -v
- git diff --cached --check

Closes #11