### PR TITLE
Add native environment lifecycle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Audit, deduplicate, route, and sync local AI skill folders for Cursor, Claude Code, Codex, and custom agent workflows.
 
+Native host path conventions are represented by environment descriptors. Cursor, Claude Code,
+and Codex are built in; another native host can reuse the same discovery-entry lifecycle by
+registering a `NativeEnvironment` instead of adding host branches to the sync algorithm.
+
 Use it when local skill directories have drifted across machines, repositories, or agent runtimes and you need a reversible audit before changing files.
 
 ## Who this is for

--- a/SKILL.md
+++ b/SKILL.md
@@ -60,6 +60,8 @@ Template: [`config/skills-auditor.pipeline.example.env`](config/skills-auditor.p
 | `SKILLS_AUDITOR_ROUTE_PLATFORMS` | Comma-separated, e.g. `cursor,codex` |
 | `SKILLS_AUDITOR_ROUTE_STRATEGY` | `archive` (default) \| `delete` \| `keep` |
 | `SKILLS_AUDITOR_SYNC_MAP_FILE` | If non-empty, sync cycle runs with this `--map-file` |
+| `SKILLS_AUDITOR_DISCOVERY_SOURCES` | Space-separated canonical source roots for discovery-driven sync; defaults to existing repo `.agents/.cursor/.claude` skill roots |
+| `SKILLS_AUDITOR_INSTALL_ROOTS` | Space-separated host discovery roots; defaults to repo `.codex/skills` when `.codex/` exists |
 | `SKILLS_AUDITOR_DRY_RUN` | `1` → **no** `--apply` on dedup / route / sync (overrides default apply) |
 | `SKILLS_AUDITOR_CONFIG` | Path to an env file to source for the above |
 
@@ -139,6 +141,13 @@ _roots="${SKILLS_AUDITOR_ROOTS:-$HOME/.cursor/skills $HOME/.claude/skills}"
 _roots="$_roots ${SKILLS_AUDITOR_EXTRA_ROOTS:-}"
 AUDIT_DIRS=()
 for d in $_roots; do [ -d "$d" ] && AUDIT_DIRS+=(--skills-dir "$d"); done
+_sync_sources="${SKILLS_AUDITOR_DISCOVERY_SOURCES:-$PWD/.agents/skills $PWD/.cursor/skills $PWD/.claude/skills}"
+SYNC_SOURCES=()
+for d in $_sync_sources; do [ -d "$d" ] && SYNC_SOURCES+=(--source "$d"); done
+_sync_targets="${SKILLS_AUDITOR_INSTALL_ROOTS:-}"
+[ -n "$_sync_targets" ] || [ ! -d "$PWD/.codex" ] || _sync_targets="$PWD/.codex/skills"
+SYNC_TARGETS=()
+for d in $_sync_targets; do SYNC_TARGETS+=(--skills-dir "$d"); done
 DRIFT_FLAG=()
 [ "${SKILLS_AUDITOR_WITH_DRIFT:-1}" = "1" ] && DRIFT_FLAG=(--with-drift)
 RSTRAT="${SKILLS_AUDITOR_ROUTE_STRATEGY:-archive}"
@@ -171,11 +180,20 @@ run_dedup() {
 run_traces() { skills-audit audit-state-machine; }
 
 run_sync() {
-  [ -n "${SKILLS_AUDITOR_SYNC_MAP_FILE:-}" ] || return 0
+  if [ -n "${SKILLS_AUDITOR_SYNC_MAP_FILE:-}" ]; then
+    if [ "${SKILLS_AUDITOR_DRY_RUN:-0}" = "1" ]; then
+      skills-audit sync "${AUDIT_DIRS[@]}" --map-file "$SKILLS_AUDITOR_SYNC_MAP_FILE"
+    else
+      skills-audit sync "${AUDIT_DIRS[@]}" --map-file "$SKILLS_AUDITOR_SYNC_MAP_FILE" --apply
+    fi
+    return
+  fi
+  [ "${#SYNC_SOURCES[@]}" -gt 0 ] && [ "${#SYNC_TARGETS[@]}" -gt 0 ] || return 0
   if [ "${SKILLS_AUDITOR_DRY_RUN:-0}" = "1" ]; then
-    skills-audit sync "${AUDIT_DIRS[@]}" --map-file "$SKILLS_AUDITOR_SYNC_MAP_FILE"
+    skills-audit sync-discover "${SYNC_SOURCES[@]}" "${SYNC_TARGETS[@]}"
   else
-    skills-audit sync "${AUDIT_DIRS[@]}" --map-file "$SKILLS_AUDITOR_SYNC_MAP_FILE" --apply
+    skills-audit sync-discover "${SYNC_SOURCES[@]}" "${SYNC_TARGETS[@]}" --apply
+    for d in $_sync_targets; do AUDIT_DIRS+=(--skills-dir "$d"); done
   fi
 }
 

--- a/config/skills-auditor.pipeline.example.env
+++ b/config/skills-auditor.pipeline.example.env
@@ -23,6 +23,12 @@ SKILLS_AUDITOR_ROUTE_STRATEGY=archive
 # If set and non-empty, cycle 5 runs sync with this map file
 # SKILLS_AUDITOR_SYNC_MAP_FILE=/absolute/path/to/sources.json
 
+# Without a map file, full/sync mode discovers canonical repo sources and registers them
+# in host discovery roots. Defaults: existing $PWD/.agents|.cursor|.claude/skills sources,
+# and $PWD/.codex/skills as target when the repository has a .codex directory.
+# SKILLS_AUDITOR_DISCOVERY_SOURCES="$PWD/.agents/skills $PWD/.cursor/skills"
+# SKILLS_AUDITOR_INSTALL_ROOTS="$PWD/.codex/skills"
+
 # SKILLS_AUDITOR_CONFIG=$HOME/.config/skills-auditor/pipeline.env
 
 # 1 = plan only (no --apply on dedup / route / sync). Unset or 0 = apply (top skill default).

--- a/skills/sync/SKILL.md
+++ b/skills/sync/SKILL.md
@@ -36,13 +36,15 @@ skills-audit sync-discover \
 ## Safety
 
 - Raw CLI defaults to dry-run for both `sync` and `sync-discover`; **`/skills-auditor`** top skill defaults to **`--apply`** on sync when `SKILLS_AUDITOR_SYNC_MAP_FILE` is set, unless dry-run or `SKILLS_AUDITOR_DRY_RUN=1`.
+- A `sync-discover` dry-run exits **1** when discovery entries are missing or stale, **5** for skipped unsafe actions, and **0** only when every discovered entry is already current. Apply creates a missing install root before registering entries.
+- In the top-level full pipeline, an explicit map remains authoritative. Without one, existing repository `.agents/.cursor/.claude` roots are discovered and registered into `.codex/skills` when the repository has a `.codex/` directory. Override with `SKILLS_AUDITOR_DISCOVERY_SOURCES` and `SKILLS_AUDITOR_INSTALL_ROOTS`.
 - `sync-discover` converts slash names to top-level install aliases and excludes each target root from its own generated plan to avoid replacing canonical local directories with self-links.
 
 ## Ledger behavior
 
 - Mode: dry-run is read-only; `--apply` may create, replace, or relink skill entries in each target root.
 - Suggested rows: `skill-run` for the sync cycle, `external-resource` for the map file or discovery sources, and `artifact` rows for captured sync plans or applied link changes.
-- Applied link changes should include locators for the target skill root entries and metadata such as `action=create_link`, `replace_link`, or `backup_and_link`.
+- Applied link changes should include locators for the target skill root entries and metadata such as `action=create_link`, `replace_link`, or `archive_and_link`.
 - Skipped or unsafe actions should become `blocked` rows with the reason, or `handoff` rows when a human/operator must decide.
 
 ## Parent

--- a/skills_auditor/cli.py
+++ b/skills_auditor/cli.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from skills_auditor.environments import BUILTIN_ENVIRONMENTS, builtin_project_skill_roots
 from skills_auditor.ledger import DEFAULT_LEDGER_ROOT, VALID_RESOURCE_CLASSES, VALID_STATUSES
 
 # Sentinel: source applies to all target platforms when syncing / filtering.
@@ -51,7 +52,7 @@ class EntryStatus:
 class SyncAction:
     name: str
     expected_target: str
-    action: str  # noop | create_link | replace_link | backup_and_link | skip_error
+    action: str  # noop | create_link | replace_link | archive_and_link | skip_error
     reason: str
 
 
@@ -1786,17 +1787,14 @@ def discover_sync_mapping(
 
 def default_sync_discover_sources(include_global_sources: bool) -> List[Path]:
     cwd = Path.cwd()
-    sources = [
-        cwd / ".agents" / "skills",
-        cwd / ".cursor" / "skills",
-        cwd / ".claude" / "skills",
-    ]
+    sources = [cwd / ".agents" / "skills", *builtin_project_skill_roots(cwd)]
     if include_global_sources:
         home = Path("~").expanduser()
-        sources.extend([
-            home / ".cursor" / "skills",
-            home / ".claude" / "skills",
-        ])
+        sources.extend(
+            root
+            for environment in BUILTIN_ENVIRONMENTS.all()
+            for root in environment.global_roots(home)
+        )
     return sources
 
 
@@ -1885,8 +1883,8 @@ def plan_sync(
                 SyncAction(
                     name=name,
                     expected_target=str(target),
-                    action="backup_and_link",
-                    reason="non-symlink entry exists",
+                    action="archive_and_link",
+                    reason="native entry exists and must be archived before linking",
                 )
             )
             continue
@@ -1895,6 +1893,9 @@ def plan_sync(
 
 
 def apply_actions(skills_dir: Path, actions: List[SyncAction]) -> None:
+    actionable = {"create_link", "replace_link", "archive_and_link"}
+    if any(action.action in actionable for action in actions):
+        skills_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     for action in actions:
         entry = skills_dir / action.name
@@ -1913,10 +1914,10 @@ def apply_actions(skills_dir: Path, actions: List[SyncAction]) -> None:
             os.symlink(str(target), str(entry))
             continue
 
-        if action.action == "backup_and_link":
-            backup_name = f"{action.name}.backup-{timestamp}"
-            backup_path = skills_dir / backup_name
-            entry.rename(backup_path)
+        if action.action == "archive_and_link":
+            archive_name = f"{action.name}.archived-{timestamp}"
+            archive_path = skills_dir / archive_name
+            entry.rename(archive_path)
             os.symlink(str(target), str(entry))
             continue
 
@@ -2247,13 +2248,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=[],
         help=(
             "Source root to scan recursively for SKILL.md. Repeatable. "
-            "If omitted, scans .agents/skills, .cursor/skills, and .claude/skills under cwd."
+            "If omitted, scans .agents/skills plus every registered built-in native "
+            "environment under cwd."
         ),
     )
     p_sync_discover.add_argument(
         "--include-global-sources",
         action="store_true",
-        help="Also append ~/.cursor/skills and ~/.claude/skills as source roots.",
+        help="Also append every built-in native environment's global skill roots.",
     )
     p_sync_discover.add_argument(
         "--apply", action="store_true", help="Apply actions (default is dry-run)"
@@ -2757,6 +2759,8 @@ def main() -> int:
             else default_sync_discover_sources(args.include_global_sources)
         )
         roots = resolve_skills_dirs(args.skills_dirs)
+        needs_apply = False
+        skipped = False
         for idx, skills_dir in enumerate(roots):
             if idx > 0:
                 print()
@@ -2765,10 +2769,19 @@ def main() -> int:
             print(f"discovered: {len(mapping)} sync entr{'y' if len(mapping) == 1 else 'ies'}")
             actions = plan_sync(skills_dir, mapping)
             print_plan(actions, args.apply)
+            needs_apply = needs_apply or any(
+                action.action in {"create_link", "replace_link", "archive_and_link"}
+                for action in actions
+            )
+            skipped = skipped or any(action.action.startswith("skip_") for action in actions)
             if args.apply:
                 apply_actions(skills_dir, actions)
         if args.apply:
             print("\nApplied actions. Re-run audit to verify final state.")
+        if skipped:
+            return 5
+        if needs_apply and not args.apply:
+            return 1
         return 0
 
     if args.command == "dedup":

--- a/skills_auditor/environments.py
+++ b/skills_auditor/environments.py
@@ -1,0 +1,70 @@
+"""Native skill-host environment descriptors.
+
+Keep host path conventions out of discovery and lifecycle algorithms. A third-party
+host can participate by supplying another ``NativeEnvironment`` descriptor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class NativeEnvironment:
+    key: str
+    project_skill_roots: Tuple[str, ...]
+    global_skill_roots: Tuple[str, ...]
+
+    def project_roots(self, project_root: Path) -> Tuple[Path, ...]:
+        return tuple(project_root / relative for relative in self.project_skill_roots)
+
+    def global_roots(self, home: Path) -> Tuple[Path, ...]:
+        return tuple(home / relative for relative in self.global_skill_roots)
+
+    def primary_project_root(self, project_root: Path) -> Path:
+        if not self.project_skill_roots:
+            raise ValueError(f"Environment {self.key!r} has no project skill root")
+        return self.project_roots(project_root)[0]
+
+
+class NativeEnvironmentRegistry:
+    def __init__(self, environments: Iterable[NativeEnvironment] = ()) -> None:
+        self._environments: Dict[str, NativeEnvironment] = {}
+        for environment in environments:
+            self.register(environment)
+
+    def register(self, environment: NativeEnvironment) -> None:
+        if not environment.key.strip():
+            raise ValueError("Environment key must not be empty")
+        if environment.key in self._environments:
+            raise ValueError(f"Environment already registered: {environment.key}")
+        self._environments[environment.key] = environment
+
+    def get(self, key: str) -> NativeEnvironment:
+        try:
+            return self._environments[key]
+        except KeyError as exc:
+            known = ", ".join(sorted(self._environments))
+            raise ValueError(f"Unknown environment {key!r}; known: {known}") from exc
+
+    def all(self) -> Tuple[NativeEnvironment, ...]:
+        return tuple(self._environments.values())
+
+
+BUILTIN_ENVIRONMENTS = NativeEnvironmentRegistry(
+    (
+        NativeEnvironment("cursor", (".cursor/skills",), (".cursor/skills",)),
+        NativeEnvironment("claude-code", (".claude/skills",), (".claude/skills",)),
+        NativeEnvironment("codex", (".codex/skills",), (".codex/skills",)),
+    )
+)
+
+
+def builtin_project_skill_roots(project_root: Path) -> Tuple[Path, ...]:
+    return tuple(
+        root
+        for environment in BUILTIN_ENVIRONMENTS.all()
+        for root in environment.project_roots(project_root)
+    )

--- a/tests/test_environment_lifecycle.py
+++ b/tests/test_environment_lifecycle.py
@@ -1,0 +1,99 @@
+"""Cross-environment discovery-entry lifecycle contract tests."""
+
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from skills_auditor.cli import apply_actions, discover_sync_mapping, main, plan_sync
+from skills_auditor.environments import (
+    BUILTIN_ENVIRONMENTS,
+    NativeEnvironment,
+    NativeEnvironmentRegistry,
+)
+
+
+class TestEnvironmentLifecycle(unittest.TestCase):
+    def write_skill(self, root: Path, name: str, body: str) -> Path:
+        skill = root / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: lifecycle fixture\n---\n{body}\n",
+            encoding="utf-8",
+        )
+        return skill
+
+    def run_cli(self, *argv: str) -> tuple[int, str]:
+        stdout = StringIO()
+        with patch("sys.argv", ["skills-audit", *argv]), redirect_stdout(stdout):
+            exit_code = main()
+        return exit_code, stdout.getvalue()
+
+    def test_discover_register_update_archive_lifecycle_in_all_builtin_environments(self) -> None:
+        for environment in BUILTIN_ENVIRONMENTS.all():
+            with self.subTest(environment=environment.key), tempfile.TemporaryDirectory() as base:
+                project = Path(base)
+                canonical_root = project / ".agents" / "skills"
+                canonical = self.write_skill(canonical_root, "product-research", "canonical-v1")
+                install_root = environment.primary_project_root(project)
+
+                mapping = discover_sync_mapping([canonical_root], exclude_target_root=install_root)
+                self.assertEqual(mapping, {"product-research": str(canonical.resolve())})
+
+                dry_code, dry_output = self.run_cli(
+                    "sync-discover",
+                    "--source",
+                    str(canonical_root),
+                    "--skills-dir",
+                    str(install_root),
+                )
+                self.assertEqual(dry_code, 1)
+                self.assertIn("product-research\tcreate_link", dry_output)
+
+                apply_actions(install_root, plan_sync(install_root, mapping))
+                entry = install_root / "product-research"
+                self.assertEqual(entry.resolve(), canonical.resolve())
+
+                stale = self.write_skill(project / "stale", "product-research", "stale")
+                entry.unlink()
+                entry.symlink_to(stale, target_is_directory=True)
+                update_plan = plan_sync(install_root, mapping)
+                self.assertEqual(update_plan[0].action, "replace_link")
+                apply_actions(install_root, update_plan)
+                self.assertEqual(entry.resolve(), canonical.resolve())
+
+                entry.unlink()
+                self.write_skill(install_root, "product-research", "native-local-copy")
+                archive_plan = plan_sync(install_root, mapping)
+                self.assertEqual(archive_plan[0].action, "archive_and_link")
+                apply_actions(install_root, archive_plan)
+                archives = list(install_root.glob("product-research.archived-*"))
+                self.assertEqual(len(archives), 1)
+                self.assertIn("native-local-copy", (archives[0] / "SKILL.md").read_text())
+                self.assertEqual(entry.resolve(), canonical.resolve())
+
+                verify_plan = plan_sync(install_root, mapping)
+                self.assertEqual([action.action for action in verify_plan], ["noop"])
+
+    def test_third_party_environment_can_be_added_without_lifecycle_changes(self) -> None:
+        registry = NativeEnvironmentRegistry(BUILTIN_ENVIRONMENTS.all())
+        registry.register(
+            NativeEnvironment("acme-agent", (".acme/skills",), (".acme/skills",))
+        )
+
+        with tempfile.TemporaryDirectory() as base:
+            project = Path(base)
+            environment = registry.get("acme-agent")
+            install_root = environment.primary_project_root(project)
+            source_root = project / ".agents" / "skills"
+            canonical = self.write_skill(source_root, "product-research", "canonical")
+            mapping = discover_sync_mapping([source_root], exclude_target_root=install_root)
+            apply_actions(install_root, plan_sync(install_root, mapping))
+
+            self.assertEqual(install_root, project / ".acme/skills")
+            self.assertEqual((install_root / "product-research").resolve(), canonical.resolve())
+            self.assertEqual([a.action for a in plan_sync(install_root, mapping)], ["noop"])
+
+        self.assertEqual(len(registry.all()), 4)

--- a/tests/test_sync_discover.py
+++ b/tests/test_sync_discover.py
@@ -57,6 +57,5 @@ class TestSyncDiscover(unittest.TestCase):
             mapping = discover_sync_mapping([source])
             self.assertEqual(mapping["external-skill"], str(external_skill.resolve()))
 
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- add a native environment descriptor and registry for Cursor, Claude Code, and Codex
- make discovery-driven sync derive built-in source roots from that registry
- detect missing or stale discovery entries with non-zero dry-run exit codes
- archive native directories before replacing them with canonical links
- add one cross-environment lifecycle test module covering discover, register, update, archive, and idempotent verification
- prove a third-party native environment can reuse the lifecycle by registering only a descriptor

## Why

The auditor could validate a canonical Skill while missing the host-specific discovery entry, allowing a full audit to appear green even though the Skill was absent from the host menu. Host path conventions were also hard-coded across implementation and tests.

## Validation

- `python3 -m unittest discover -s tests -v` — 122 tests passed
- `python3 -m compileall -q skills_auditor`
- `git diff --check`
